### PR TITLE
coverprofile: Ignore test.rs files

### DIFF
--- a/hack/coverprofile.sh
+++ b/hack/coverprofile.sh
@@ -27,8 +27,8 @@ export LLVM_PROFILE_FILE="cargo-test-%p-%m.profraw"
 
 cargo test
 
-grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html
-grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/lcov.info
+grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore "**/test.rs" -o target/coverage/html
+grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore "**/test.rs" -o target/coverage/lcov.info
 
 if compgen -G "./*.profraw" >/dev/null; then
     rm ./*.profraw


### PR DESCRIPTION
Test code should not count towards coverage.