### PR TITLE
CI: Use cargo-version and cargo-release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,10 @@ name: CI
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Use to set tag, default: rolling"
-        type: string
-        default: "rolling"
+      release:
+        description: "Release build"
+        type: boolean
+        default: false
         required: false
       dry-run:
         description: "Do not push image"
@@ -21,10 +21,10 @@ on:
         required: false
   workflow_call:
     inputs:
-      tag:
-        description: "Use to set tag, default: rolling"
-        type: string
-        default: "rolling"
+      release:
+        description: "Release build"
+        type: boolean
+        default: false
         required: false
       dry-run:
         description: "Do not push image"
@@ -56,6 +56,11 @@ on:
     branches: ["main"]
 
 jobs:
+  extract-version:
+    uses: heathcliff26/ci/.github/workflows/cargo-version.yaml@main
+    permissions:
+      contents: read
+
   doc:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
     permissions:
@@ -111,13 +116,14 @@ jobs:
       contents: read
       packages: write
     needs:
+      - extract-version
       - doc
       - lint
       - test
       - validate
     with:
       dockerfile: Dockerfile
-      tag: "${{ inputs.tag == '' && 'rolling' || inputs.tag }}"
+      tag: "${{ inputs.release && needs.extract-version.outputs.version || 'rolling' }}"
       tags: "${{ inputs.latest == true && 'type=raw,value=latest' || '' }}"
       dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,6 @@ on:
         description: "Update existing release"
         type: boolean
         default: false
-      tag:
-        description: "Release tag to use"
-        type: string
-        required: true
       latest:
         description: "Tag container as latest"
         type: boolean
@@ -26,26 +22,18 @@ on:
         default: false
 
 jobs:
-  preflight:
-    uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
+  extract-version:
+    uses: heathcliff26/ci/.github/workflows/cargo-version.yaml@main
     permissions:
       contents: read
-    with:
-      cmd: |
-        set -e
-        version="v$(yq -r '.package.version' Cargo.toml)"
-        if [[ "${{ inputs.tag }}" != "${version}" ]]; then
-          echo "Tag '${{ inputs.tag }}' does not match version '${version}' in Cargo.toml"
-          exit 1
-        fi
 
   tag:
     uses: heathcliff26/ci/.github/workflows/tag.yaml@main
-    needs: preflight
+    needs: extract-version
     permissions:
       contents: write
     with:
-      tag: ${{ inputs.tag }}
+      tag: ${{ needs.extract-version.outputs.version }}
       overwrite: ${{ inputs.update }}
     secrets: inherit
 
@@ -57,30 +45,29 @@ jobs:
       packages: write
       security-events: write
     with:
-      tag: ${{ inputs.tag }}
+      release: true
       latest: ${{ inputs.latest }}
     secrets: inherit
 
   release:
     uses: heathcliff26/ci/.github/workflows/release.yaml@main
-    needs: build
+    needs:
+      - build
+      - extract-version
     permissions:
       contents: write
     with:
       draft: ${{ inputs.draft }}
       update: ${{ inputs.update }}
-      tag: ${{ inputs.tag }}
+      tag: ${{ needs.extract-version.outputs.version }}
       release-artifacts: "release/*"
       artifacts: "cerberus-mergeguard-*"
       prerelease: ${{ inputs.prerelease }}
 
   publish-crate:
-    uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
+    uses: heathcliff26/ci/.github/workflows/cargo-release.yaml@main
     if: ${{ inputs.draft == false && inputs.update == false }}
     needs: build
     permissions:
       contents: read
-    with:
-      cmd: |
-        echo '${{ secrets.CRATES_IO_API_TOKEN }}' | cargo login
-        cargo publish
+    secrets: inherit


### PR DESCRIPTION
Read version/tag from Cargo.toml instead of manually inputting it. Move cargo-release script to CI repo.