### PR TITLE
types.rs: Remove unused fields

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -61,34 +61,10 @@ async fn pull_request_event() {
         number: 1,
         pull_request: PullRequest {
             title: "Test Pull Request".to_string(),
-            state: "open".to_string(),
-            merged: false,
-            user: User {
-                login: "test_user".to_string(),
-                id: 987654,
-            },
             head: BranchRef {
                 label: "base_label".to_string(),
                 sha: "base_sha".to_string(),
                 ref_field: "base_ref".to_string(),
-                user: User {
-                    login: "base_user".to_string(),
-                    id: 123456,
-                },
-                repo: Repo {
-                    id: 12345678,
-                    name: "test_repo".to_string(),
-                    full_name: "test_user/test_repo".to_string(),
-                },
-            },
-            base: BranchRef {
-                label: "base_label".to_string(),
-                sha: "base_sha".to_string(),
-                ref_field: "base_ref".to_string(),
-                user: User {
-                    login: "base_user".to_string(),
-                    id: 123456,
-                },
                 repo: Repo {
                     id: 12345678,
                     name: "test_repo".to_string(),
@@ -102,10 +78,6 @@ async fn pull_request_event() {
             id: 12345678,
             name: "test_repo".to_string(),
             full_name: "test_user/test_repo".to_string(),
-        },
-        sender: User {
-            login: "test_user".to_string(),
-            id: 987654,
         },
     };
     let response = reqwest::Client::new()

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,7 +27,6 @@ pub struct PullRequestEvent {
     pub number: u64,
     pub pull_request: PullRequest,
     pub repository: Repo,
-    pub sender: User,
 }
 
 /// Partial fields of a check_run event webhook payload.
@@ -37,7 +36,6 @@ pub struct CheckRunEvent {
     pub check_run: CheckRun,
     pub installation: Option<Installation>,
     pub repository: Repo,
-    pub sender: User,
 }
 
 /// Partial fields of a pull_request object.
@@ -45,18 +43,7 @@ pub struct CheckRunEvent {
 pub struct PullRequest {
     pub number: u64,
     pub title: String,
-    pub state: String,
-    pub merged: bool,
-    pub user: User,
-    pub base: BranchRef,
     pub head: BranchRef,
-}
-
-/// Partial fields of a user object.
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct User {
-    pub login: String,
-    pub id: u64,
 }
 
 /// Partial fields of a branch reference object.
@@ -66,7 +53,6 @@ pub struct BranchRef {
     #[serde(rename = "ref")]
     pub ref_field: String,
     pub sha: String,
-    pub user: User,
     pub repo: Repo,
 }
 
@@ -150,7 +136,6 @@ pub struct App {
     pub client_id: String,
     pub slug: String,
     pub name: String,
-    pub owner: User,
 }
 
 /// Partial fields of an installation object.


### PR DESCRIPTION
Remove fields not needed for the operation of the bot.
This reduces overhead in testing and runtime memory usage.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>