### PR TITLE
Fix small race condition in client unit-test

### DIFF
--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -124,7 +124,7 @@ async fn failed_to_get_token() {
 
     let api_server = MockGithubApiServer::new(expected_requests);
     let addr = api_server.start().await;
-    let certificate = TlsCertificate::create("/tmp/get_new_token_when_expired");
+    let certificate = TlsCertificate::create("/tmp/failed_to_get_token");
     let client = ClientOptions {
         client_id: "testid".to_string(),
         private_key: certificate.key.clone(),


### PR DESCRIPTION
Fix problem of same name tls certificates.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>
