### PR TITLE
Implement custom error type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{client, server};
+use crate::{client, error::Error, server};
 use serde::{Deserialize, Serialize};
 use std::fs;
 
@@ -23,15 +23,15 @@ fn default_log_level() -> String {
 
 impl Configuration {
     /// Load the configuration from a file
-    pub fn load(path: &str) -> Result<Self, String> {
+    pub fn load(path: &str) -> Result<Self, Error> {
         // TODO: Replace with supported version
-        let contents = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read config file '{}': {}", path, e))?;
+        let contents =
+            fs::read_to_string(path).map_err(|e| Error::ReadConfigFile(path.to_string(), e))?;
 
         let config: Self = serde_yaml::from_str(&contents)
-            .map_err(|e| format!("Failed to parse config file '{}': {}", path, e))?;
+            .map_err(|e| Error::ParseConfigFile(path.to_string(), e))?;
 
-        config.validate()?;
+        config.validate().map_err(Error::InvalidConfig)?;
         Ok(config)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,81 @@
+use std::fmt::Display;
+
+/// Error type for the application, encapsulating various error scenarios
+#[derive(Debug)]
+pub enum Error {
+    ReadPrivateKey(String, std::io::Error),
+    EncodingKey(jsonwebtoken::errors::Error),
+    #[allow(clippy::upper_case_acronyms)]
+    JWT(jsonwebtoken::errors::Error),
+    InvalidBearerToken(),
+    CreateRequest(reqwest::Error),
+    Send(reqwest::Error),
+    NonOkStatus(String, reqwest::StatusCode),
+    Parse(&'static str, Box<dyn std::error::Error>),
+    ReceiveBody(reqwest::Error),
+    Serve(std::io::Error),
+    BindPort(Box<dyn std::error::Error>),
+    ReadConfigFile(String, std::io::Error),
+    ParseConfigFile(String, serde_yaml::Error),
+    InvalidConfig(&'static str),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::ReadPrivateKey(path, err) => {
+                write!(f, "Failed to read private key '{path}': {err}")
+            }
+            Error::EncodingKey(err) => {
+                write!(f, "Failed to create encoding key: {err}")
+            }
+            Error::JWT(err) => {
+                write!(f, "Failed to create JWT token: {err}")
+            }
+            Error::InvalidBearerToken() => {
+                write!(f, "Invalid bearer token provided.")
+            }
+            Error::CreateRequest(err) => {
+                write!(f, "Failed to create request: {err}")
+            }
+            Error::Send(err) => {
+                write!(f, "Failed to send request: {}", full_error_stack(err))
+            }
+            Error::NonOkStatus(url, status) => {
+                write!(f, "Request to '{url}' failed with status: {status}")
+            }
+            Error::Parse(url, err) => {
+                write!(f, "Failed to parse response from '{url}': {err}")
+            }
+            Error::ReceiveBody(err) => {
+                write!(f, "Failed to read response body: {err}")
+            }
+            Error::Serve(err) => {
+                write!(f, "Server error: {err}")
+            }
+            Error::BindPort(err) => {
+                write!(f, "Failed to bind port: {err}")
+            }
+            Error::ReadConfigFile(path, err) => {
+                write!(f, "Failed to read config file '{path}': {err}")
+            }
+            Error::ParseConfigFile(path, err) => {
+                write!(f, "Failed to parse config file '{path}': {err}")
+            }
+            Error::InvalidConfig(msg) => {
+                write!(f, "Invalid configuration: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+fn full_error_stack(mut e: &dyn std::error::Error) -> String {
+    let mut s = format!("{e}");
+    while let Some(src) = e.source() {
+        s.push_str(&format!(": {}", src));
+        e = src;
+    }
+    s
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use tracing::Level;
 mod api;
 mod client;
 mod config;
+mod error;
 mod server;
 #[cfg(test)]
 mod test;
@@ -28,13 +29,12 @@ pub struct App {
 
 impl App {
     /// Run the application based on the provided command and options.
-    pub async fn run(self) -> Result<(), String> {
+    pub async fn run(self) -> Result<(), error::Error> {
         if let Command::Version = self.command {
             version::print_version_and_exit();
         }
 
-        let config = config::Configuration::load(&self.global_opts.config)
-            .map_err(|e| format!("Failed to load configuration: {e}"))?;
+        let config = config::Configuration::load(&self.global_opts.config)?;
 
         let log_level = match self.global_opts.log {
             Some(level) => level,
@@ -164,7 +164,7 @@ fn set_log_level(level: &str) {
 async fn get_and_print_status(
     cli_opts: &CLIOptions,
     client: &client::Client,
-) -> Result<(u32, Option<types::CheckRun>), String> {
+) -> Result<(u32, Option<types::CheckRun>), error::Error> {
     let (count, own_run) = client
         .get_check_run_status(
             cli_opts.app_installation_id,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -97,7 +97,7 @@ async fn pull_request_event() {
     let state = server.state.lock().await;
 
     // Check that the token request was made
-    let request = state.requests.get(0).expect("Should have token request");
+    let request = state.requests.first().expect("Should have token request");
     assert_eq!("POST", request.method.as_str(), "Method should be POST");
     assert_eq!(
         "/app/installations/123456/access_tokens",
@@ -181,7 +181,7 @@ async fn check_run_event_incomplete() {
 
     let check_run_event = CheckRunEvent {
         action: "created".to_string(),
-        check_run: check_run,
+        check_run,
         installation: Some(Installation { id: 123456 }),
         repository: Repo {
             id: 12345678,
@@ -207,7 +207,7 @@ async fn check_run_event_incomplete() {
     let state = server.state.lock().await;
 
     // Check that the token request was made
-    let request = state.requests.get(0).expect("Should have token request");
+    let request = state.requests.first().expect("Should have token request");
     assert_eq!("POST", request.method.as_str(), "Method should be POST");
     assert_eq!(
         "/app/installations/123456/access_tokens",
@@ -276,7 +276,7 @@ async fn check_run_event_ignore_own() {
 
     let check_run_event = CheckRunEvent {
         action: "created".to_string(),
-        check_run: check_run,
+        check_run,
         installation: Some(Installation { id: 123456 }),
         repository: Repo {
             id: 12345678,

--- a/src/testutils/mod.rs
+++ b/src/testutils/mod.rs
@@ -113,20 +113,20 @@ impl ExpectedRequests {
     pub fn response(&self) -> (StatusCode, String) {
         match self {
             ExpectedRequests::GetInstallationToken(status, token_response) => (
-                status.clone(),
+                *status,
                 serde_json::to_string(&token_response).expect("Failed to serialize token response"),
             ),
             ExpectedRequests::GetCheckRuns(status, check_runs_response) => (
-                status.clone(),
+                *status,
                 serde_json::to_string(&check_runs_response)
                     .expect("Failed to serialize token response"),
             ),
             ExpectedRequests::CreateCheckRun(status, check_run) => (
-                status.clone(),
+                *status,
                 serde_json::to_string(&check_run).expect("Failed to serialize token response"),
             ),
             ExpectedRequests::UpdateCheckRun(status, check_run) => (
-                status.clone(),
+                *status,
                 serde_json::to_string(&check_run).expect("Failed to serialize token response"),
             ),
         }


### PR DESCRIPTION
Instead of returning strings, use a custom error type.

Closes: #32

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>