### PR TITLE
Implement refresh via pr comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ In order to create and update status checks, github requires an app. To create a
    - GitHub App name: The display name of your app, e.g. Cerberus Mergeguard
    - Homepage URL: URL to your Website
    - Webhook URL: The URL where your bot is running, e.g. <https://example.org/webhook>
-   - Webhook Secret: Optional create a random string to enter here, to verify that webhook requests are send by github
+   - Webhook Secret: Optional create a random string to enter here, to verify that webhook requests are sent by github
    - Permissions -> Repository permissions:
      - Checks: Read/Write
+     - Issues: Read
+     - Pull requests: Read
    - Events:
      - Check run
+     - Issue comment
      - Pull request
 6. After creating your app, go to your app -> "Private Keys" and generate a new key
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -110,6 +110,30 @@ pub async fn update_check_run(
     }
 }
 
+/// Get the current status of a pull request.
+/// API endpoint: GET /repos/{owner}/{repo}/pulls/{pull_number}
+pub async fn get_pull_request(
+    endpoint: &str,
+    token: &str,
+    repo: &str,
+    pull_number: u64,
+) -> Result<PullRequestResponse, Error> {
+    let url = format!("{endpoint}/repos/{repo}/pulls/{pull_number}");
+    info!("Fetching pull request from '{url}'");
+
+    let client = new_client_with_common_headers(token)?;
+    let response = send_request(client.get(&url)).await?;
+    let response = receive_body(response).await?;
+
+    match serde_json::from_str::<PullRequestResponse>(&response) {
+        Ok(pull_request) => Ok(pull_request),
+        Err(e) => {
+            debug!("Response body: '{}'", response);
+            Err(Error::Parse("get_pull_request", Box::new(e)))
+        }
+    }
+}
+
 fn new_client_with_common_headers(token: &str) -> Result<Client, Error> {
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/src/server/testdata/issue-comment-event-ignored.json
+++ b/src/server/testdata/issue-comment-event-ignored.json
@@ -1,0 +1,19 @@
+{
+  "action": "created",
+  "issue": {
+    "id": 3130403522,
+    "number": 56
+  },
+  "comment": {
+    "id": 2955890178,
+    "body": "Not the string we are looking for"
+  },
+  "repository": {
+    "id": 990804936,
+    "name": "cerberus-mergeguard",
+    "full_name": "heathcliff26/cerberus-mergeguard"
+  },
+  "installation": {
+    "id": 68583790
+  }
+}

--- a/src/server/testdata/issue-comment-event-refresh.json
+++ b/src/server/testdata/issue-comment-event-refresh.json
@@ -1,0 +1,19 @@
+{
+  "action": "created",
+  "issue": {
+    "id": 3130403522,
+    "number": 56
+  },
+  "comment": {
+    "id": 2955890178,
+    "body": "/cerberus refresh"
+  },
+  "repository": {
+    "id": 990804936,
+    "name": "cerberus-mergeguard",
+    "full_name": "heathcliff26/cerberus-mergeguard"
+  },
+  "installation": {
+    "id": 68583790
+  }
+}

--- a/src/testutils/mod.rs
+++ b/src/testutils/mod.rs
@@ -106,6 +106,7 @@ pub enum ExpectedRequests {
     GetCheckRuns(StatusCode, CheckRunsResponse),
     CreateCheckRun(StatusCode, CheckRun),
     UpdateCheckRun(StatusCode, CheckRun),
+    GetPullRequest(StatusCode, PullRequestResponse),
 }
 
 impl ExpectedRequests {
@@ -128,6 +129,11 @@ impl ExpectedRequests {
             ExpectedRequests::UpdateCheckRun(status, check_run) => (
                 *status,
                 serde_json::to_string(&check_run).expect("Failed to serialize token response"),
+            ),
+            ExpectedRequests::GetPullRequest(status, pull_request_response) => (
+                *status,
+                serde_json::to_string(&pull_request_response)
+                    .expect("Failed to serialize pull request response"),
             ),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,6 +39,16 @@ pub struct CheckRunEvent {
     pub repository: Repo,
 }
 
+/// Partial fields of an issue_comment event webhook payload.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IssueCommentEvent {
+    pub action: String,
+    pub issue: Issue,
+    pub comment: Comment,
+    pub installation: Option<Installation>,
+    pub repository: Repo,
+}
+
 /// Partial fields of a pull_request object.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PullRequest {
@@ -174,6 +184,20 @@ pub struct Installation {
     pub id: u64,
 }
 
+/// Partial fields of a comment object.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Comment {
+    pub id: u64,
+    pub body: String,
+}
+
+/// Partial fields of an issue object.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: u64,
+    pub number: u64,
+}
+
 /// Response to check-run requests from the GitHub API.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CheckRunsResponse {
@@ -186,4 +210,12 @@ pub struct CheckRunsResponse {
 pub struct TokenResponse {
     pub token: String,
     pub expires_at: DateTime<Utc>,
+}
+
+/// Response to get pull request from the GitHub API.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PullRequestResponse {
+    pub id: u64,
+    pub number: u64,
+    pub head: BranchRef,
 }

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -103,3 +103,15 @@ fn parse_token_response() {
 
     assert_eq!("ghs_16C7e42F292c6912E7710c838347Ae178B4a", token.token);
 }
+
+#[test]
+fn parse_pull_request_response() {
+    let test_body = include_str!("testdata/pr-response.json");
+
+    let pr: PullRequestResponse = match serde_json::from_str(test_body) {
+        Ok(pr) => pr,
+        Err(e) => panic!("Failed to parse pull request response: {e}"),
+    };
+
+    assert_eq!(1347, pr.number);
+}

--- a/src/types/testdata/pr-response.json
+++ b/src/types/testdata/pr-response.json
@@ -1,0 +1,14 @@
+{
+  "id": 1,
+  "number": 1347,
+  "head": {
+    "label": "octocat:new-topic",
+    "ref": "new-topic",
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+    "repo": {
+      "id": 1296269,
+      "name": "Hello-World",
+      "full_name": "octocat/Hello-World"
+    }
+  }
+}


### PR DESCRIPTION
Allow users to refresh the current check-run status by issuing a command to the
bot via github comments.

Closes: #5

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>