### PR TITLE
Ignore skipped check-runs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -224,7 +224,7 @@ impl Client {
                     if run
                         .conclusion
                         .as_ref()
-                        .is_some_and(|v| v == CHECK_RUN_CONCLUSION)
+                        .is_some_and(|v| v == CHECK_RUN_CONCLUSION || v == "skipped")
                     {
                         debug!("Check run '{}' is completed successfully", run.name);
                     } else {


### PR DESCRIPTION
When checking if all checks have passed, ignore skipped checks.

Fixes: #59

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>