### PR TITLE
client: Add test for counting unfinished check runs

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,8 @@ pub const CHECK_RUN_INITIAL_STATUS: &str = "queued";
 pub const CHECK_RUN_COMPLETED_STATUS: &str = "completed";
 /// Conclusion for completed check-runs from the bot
 pub const CHECK_RUN_CONCLUSION: &str = "success";
+/// Conclusion for skipped check-runs from the bot
+pub const CHECK_RUN_SKIPPED: &str = "skipped";
 /// Title for unfinished check-runs from the bot
 pub const CHECK_RUN_INITIAL_TITLE: &str = "Waiting for other checks to complete";
 /// Title for completed check-runs from the bot


### PR DESCRIPTION
Add multiple test cases covering the overall_check_status function.
Additionally fix the linter warning in the function.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>