### PR TITLE
testutils: Simplify test certificates by using the tempfile crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-native-tls",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ e2e = ["dep:rand"]
 
 [dev-dependencies]
 rand = "0.9.2"
+tempfile = "3.23.0"

--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -46,7 +46,7 @@ async fn get_new_token() {
 
     let api_server = MockGithubApiServer::new(expected_requests);
     let addr = api_server.start().await;
-    let certificate = TlsCertificate::create("/tmp/cerberus-mergeguard_new_token");
+    let certificate = TlsCertificate::create();
     let client = ClientOptions {
         client_id: "testid".to_string(),
         private_key: certificate.key.clone(),
@@ -78,7 +78,7 @@ async fn get_new_token_when_expired() {
 
     let api_server = MockGithubApiServer::new(expected_requests);
     let addr = api_server.start().await;
-    let certificate = TlsCertificate::create("/tmp/get_new_token_when_expired");
+    let certificate = TlsCertificate::create();
     let client = ClientOptions {
         client_id: "testid".to_string(),
         private_key: certificate.key.clone(),
@@ -125,7 +125,7 @@ async fn failed_to_get_token() {
 
     let api_server = MockGithubApiServer::new(expected_requests);
     let addr = api_server.start().await;
-    let certificate = TlsCertificate::create("/tmp/failed_to_get_token");
+    let certificate = TlsCertificate::create();
     let client = ClientOptions {
         client_id: "testid".to_string(),
         private_key: certificate.key.clone(),

--- a/src/server/test.rs
+++ b/src/server/test.rs
@@ -173,9 +173,7 @@ async fn handle_webhook_comment_refresh_command() {
     let api_addr = server.start().await;
 
     // Prepare server state and headers
-    let certificate = TlsCertificate::create(
-        "/tmp/cerberus-mergeguard_handle_webhook_comment_refresh_command_test",
-    );
+    let certificate = TlsCertificate::create();
     let client_options = ClientOptions {
         client_id: client_id.to_string(),
         private_key: certificate.key.to_string(),
@@ -217,8 +215,7 @@ async fn webhook_check_run_job_queue() {
     let api_addr = server.start().await;
 
     // Prepare server state and headers
-    let certificate =
-        TlsCertificate::create("/tmp/cerberus-mergeguard_webhook_check_run_job_queue");
+    let certificate = TlsCertificate::create();
     let client_options = ClientOptions {
         client_id: "test-client-id".to_string(),
         private_key: certificate.key.to_string(),
@@ -328,7 +325,7 @@ async fn run_periodic_job_queue() {
     let server = MockGithubApiServer::new(expected_requests);
     let api_addr = server.start().await;
 
-    let certificate = TlsCertificate::create("/tmp/cerberus-mergeguard_run_periodic_job_queue");
+    let certificate = TlsCertificate::create();
     let client_options = ClientOptions {
         client_id: "test-client".to_string(),
         private_key: certificate.key.to_string(),

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -30,7 +30,7 @@ async fn pull_request_event() {
     let api_addr = server.start().await;
 
     let client_id = "test_client_id";
-    let certificate = TlsCertificate::create("/tmp/cerberus-mergeguard_pull_request_event_test");
+    let certificate = TlsCertificate::create();
     let mut server_options = ServerOptions::default();
     server_options.port = 8900;
     let config = Configuration {
@@ -152,8 +152,7 @@ async fn check_run_event_incomplete() {
     let api_addr = server.start().await;
 
     let client_id = "test_client_id";
-    let certificate =
-        TlsCertificate::create("/tmp/cerberus-mergeguard_check_run_event_incomplete_test");
+    let certificate = TlsCertificate::create();
     let mut server_options = ServerOptions::default();
     server_options.port = 8901;
     let config = Configuration {
@@ -237,8 +236,7 @@ async fn check_run_event_ignore_own() {
     let api_addr = server.start().await;
 
     let client_id = "test_client_id";
-    let certificate =
-        TlsCertificate::create("/tmp/cerberus-mergeguard_check_run_event_ignore_own_test");
+    let certificate = TlsCertificate::create();
     let mut server_options = ServerOptions::default();
     server_options.port = 8902;
     let config = Configuration {

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -9,7 +9,7 @@ static CONTAINER_IMAGE: &str = "localhost/cerberus-mergeguard:e2e-test";
 
 #[tokio::test]
 async fn container_image_healthcheck_http() {
-    let _cert = TlsCertificate::create("tests/e2e/testdata/http/testapp");
+    let _cert = TlsCertificate::create();
     let _container =
         RunningContainer::setup("cerberus-http", "8080:8080", "./tests/e2e/testdata/http/").await;
 
@@ -32,8 +32,8 @@ async fn container_image_healthcheck_http() {
 
 #[tokio::test]
 async fn container_image_healthcheck_https() {
-    let _app_cert = TlsCertificate::create("tests/e2e/testdata/https/testapp");
-    let server_cert = TlsCertificate::create("tests/e2e/testdata/https/server");
+    let _app_cert = TlsCertificate::create();
+    let server_cert = TlsCertificate::create();
     let _container =
         RunningContainer::setup("cerberus-https", "8443:8443", "./tests/e2e/testdata/https/").await;
 


### PR DESCRIPTION
Create random temporary directories for the certificates, instead of test
specific hardcoded ones.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>