### PR TITLE
Cargo.toml: Add tweaks to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,14 +58,16 @@ chrono = { version = "0.4.44", default-features = false, features = [
     "now",
 ] }
 
+[dev-dependencies]
+rand = "0.10.1"
+
 [profile.release]
 strip = "symbols"
 lto = true
 codegen-units = 1
+opt-level = "z"
+panic = "abort"
 
 [features]
 default = []
 e2e = ["dep:rand"]
-
-[dev-dependencies]
-rand = "0.10.1"


### PR DESCRIPTION
Lighter binaries should improve performance slightly as well.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>