### PR TITLE
CI: Fix permissions for coverprofile workflow

### DIFF
--- a/.github/workflows/coverprofiles.yaml
+++ b/.github/workflows/coverprofiles.yaml
@@ -19,6 +19,7 @@ jobs:
   generate-reports:
     uses: heathcliff26/ci/.github/workflows/testcover-report.yaml@main
     secrets: inherit
-    permissions: {}
+    permissions:
+      contents: read
     with:
       coverprofile: "target/coverage/lcov.info"


### PR DESCRIPTION
In order to run it without app token on PRs, read permissions are needed.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>