### PR TITLE
helm: Add default value for httpRoute rules

### DIFF
--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -145,11 +145,11 @@ httpRoute:
   # Hostnames matching HTTP header.
   hostnames: []
   # List of rules and filters applied.
-  rules: []
-  # - matches:
-  #   - path:
-  #       type: PathPrefix
-  #       value: /echo
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
   #     headers:
   #     - name: version
   #       value: v2


### PR DESCRIPTION
Ensure there is an initial default for the rules. Otherwise none would be rendered.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>