### PR TITLE
Accept neutral results as success

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use crate::{
     api,
     error::Error,
-    types::{CHECK_RUN_CONCLUSION, CHECK_RUN_SKIPPED, CheckRun, TokenResponse},
+    types::{CHECK_RUN_CONCLUSION, CHECK_RUN_NEUTRAL, CHECK_RUN_SKIPPED, CheckRun, TokenResponse},
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -222,11 +222,11 @@ impl Client {
             }
             match run.status.as_str() {
                 "completed" => {
-                    if run
-                        .conclusion
-                        .as_ref()
-                        .is_some_and(|v| v == CHECK_RUN_CONCLUSION || v == CHECK_RUN_SKIPPED)
-                    {
+                    if run.conclusion.as_ref().is_some_and(|v| {
+                        v == CHECK_RUN_CONCLUSION
+                            || v == CHECK_RUN_SKIPPED
+                            || v == CHECK_RUN_NEUTRAL
+                    }) {
                         debug!("Check run '{}' is completed successfully", run.name);
                     } else {
                         debug!(

--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -174,6 +174,13 @@ fn test_overall_check_status() {
             Some("other-conclusion".to_string()),
             "other-app-id",
         ),
+        create_test_check_run(
+            "commit1",
+            "check-6",
+            "completed",
+            Some(CHECK_RUN_NEUTRAL.to_string()),
+            "other-app-id",
+        ),
     ];
 
     let (count, own_check_run) = client.overall_check_status(&check_runs);

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,8 @@ pub const CHECK_RUN_COMPLETED_STATUS: &str = "completed";
 pub const CHECK_RUN_CONCLUSION: &str = "success";
 /// Conclusion for skipped check-runs from the bot
 pub const CHECK_RUN_SKIPPED: &str = "skipped";
+/// Conclusion for neutral check-runs from the bot
+pub const CHECK_RUN_NEUTRAL: &str = "neutral";
 /// Title for unfinished check-runs from the bot
 pub const CHECK_RUN_INITIAL_TITLE: &str = "Waiting for other checks to complete";
 /// Title for completed check-runs from the bot


### PR DESCRIPTION
When CodeQL is running without a configuration, it returns a neutral result. This happens for example with dependabot PRs. Merges should not be blocked here. This does mean that users need to set an additional rule for requiring code quality results themselves.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>