### PR TITLE
CI: Move helm to release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,21 +141,3 @@ jobs:
       build-args: |
         CI_COMMIT_SHA=${{ github.sha }}
     secrets: inherit
-
-  push-helm:
-    uses: heathcliff26/ci/.github/workflows/push-helm-chart.yaml@main
-    if: ${{ inputs.release }}
-    permissions:
-      contents: read
-      packages: write
-    needs:
-      - extract-version
-      - doc
-      - lint
-      - test
-      - validate
-      - e2e
-    with:
-      tag: "${{ needs.extract-version.outputs.version }}"
-      dry-run: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' || inputs.dry-run == 'true' }}
-    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,8 @@ jobs:
 
   tag:
     uses: heathcliff26/ci/.github/workflows/tag.yaml@main
-    needs: extract-version
+    needs:
+      - extract-version
     permissions:
       contents: write
     with:
@@ -39,7 +40,8 @@ jobs:
 
   build:
     uses: ./.github/workflows/ci.yaml
-    needs: tag
+    needs:
+      - tag
     permissions:
       contents: read
       packages: write
@@ -49,11 +51,24 @@ jobs:
       latest: ${{ inputs.latest }}
     secrets: inherit
 
+  push-helm:
+    uses: heathcliff26/ci/.github/workflows/push-helm-chart.yaml@main
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+      - extract-version
+    with:
+      tag: ${{ needs.extract-version.outputs.version }}
+    secrets: inherit
+
   release:
     uses: heathcliff26/ci/.github/workflows/release.yaml@main
     needs:
       - build
       - extract-version
+      - push-helm
     permissions:
       contents: write
     with:
@@ -68,7 +83,9 @@ jobs:
   publish-crate:
     uses: heathcliff26/ci/.github/workflows/cargo-release.yaml@main
     if: ${{ inputs.draft == false && inputs.update == false }}
-    needs: build
+    needs:
+      - build
+      - push-helm
     permissions:
       contents: read
     secrets: inherit


### PR DESCRIPTION
Call push-helm directly from release workflow, as it is only run during release anyway.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>